### PR TITLE
Dark model adpat

### DIFF
--- a/app/static/css/diary.css
+++ b/app/static/css/diary.css
@@ -2,30 +2,62 @@
 .diary-card {
     background-color: var(--color-card-bg);
     border-radius: 1rem;
+    color: var(--color-text);
 }
 
 .shared-with-me {
-    background-color: #eaf6ff !important; /* Light blue */
+    background-color: #eaf6ff !important;
+    /* Light blue */
     border-left: 4px solid #0d6efd;
 }
 
-/* Diary Detail Page */
+/* Form Elements for Upload Page */
+form input.form-control,
+form textarea.form-control {
+    background-color: var(--color-card-bg);
+    color: var(--color-text);
+    border: 1px solid var(--color-border);
+    border-radius: var(--border-radius-md);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+form input.form-control:hover,
+form textarea.form-control:hover {
+    background-color: var(--color-card-bg);
+    color: var(--color-text);
+    border-color: var(--color-primary);
+}
+
+form input.form-control:focus,
+form textarea.form-control:focus {
+    background-color: var(--color-card-bg);
+    color: var(--color-text);
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 0.15rem rgba(var(--color-primary-rgb), 0.25);
+    outline: none;
+}
+
+#diaryTitle::placeholder {
+    color: var(--color-text-light);
+}
+
+#diaryContent::placeholder {
+    color: var(--color-text-light);
+}
+
+
+/* Diary Card */
 .diary-content {
     font-size: 1rem;
     line-height: 1.6;
-    color: #212529;
+    color: var(--color-text);
     text-align: left;
 }
 
 .meta-info {
     font-size: 0.9rem;
     color: #6c757d;
-}
-
-.emotion-details-card {
-    background-color: #f1f3f5;
-    border-radius: 0.5rem;
-    padding: 1rem;
+    color: var(--color-text-light);
 }
 
 .emotion-badge-lg {
@@ -33,12 +65,38 @@
     padding: 0.4em 0.8em;
 }
 
+/* Detail Page */
+.diary-detail-card {
+    background-color: var(--color-card-bg);
+    color: var(--color-text);
+    border-radius: 1rem;
+    border: 1px solid var(--color-border);
+}
+
+
+.emotion-details-card {
+    background-color: var(--color-card-bg);
+    background-color: var(--color-card-bg);
+    color: var(--color-text);
+    border-radius: 0.5rem;
+    border: 1px solid var(--color-border);
+    padding: 1rem;
+}
+
+/* Share Model for Detail Page */
+.modal-content {
+    
+    background-color: var(--color-card-bg);
+    color: var(--color-text);
+    color: var(--color-text-light);
+    border: 1px solid var(--color-border);
+}
 
 /* --- Search and Filter Layout --- */
 .search-filter-row {
     display: flex;
     flex-wrap: wrap;
-    justify-content: flex-end;  
+    justify-content: flex-end;
     align-items: center;
     gap: 1rem;
     margin-bottom: 1.5rem;
@@ -68,6 +126,7 @@
 .search-filter-row input:focus,
 .search-filter-row select:focus {
     outline: none;
+    background-color: var(--color-card-bg);
     border-color: var(--color-primary);
     box-shadow: 0 0 0 0.15rem rgba(var(--color-primary-rgb), 0.25);
 }

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -30,11 +30,11 @@
         --color-primary-rgb: 160, 98, 196;
         --color-secondary: #b37cd4;
         --color-secondary-rgb: 179, 124, 212;
-        --color-bg: #1a1a1a; /* Darker background */
-        --color-bg-alt: #212121; /* Slightly lighter dark */
+        --color-bg: #121212; /* Darker background */
+        --color-bg-alt: #1e1e1e; /* Slightly lighter dark */
         --color-text: #e0e0e0;
         --color-text-light: #aaaaaa;
-        --color-card-bg: #2c2c2c; /* Dark Card */
+        --color-card-bg: #2e2e2e; /* Dark Card */
         --color-card-bg-rgb: 44, 44, 44;
         --color-border: #444444;
         --color-bg-rgb: 26, 26, 26; /* For navbar in dark mode, Corresponds to #1a1a1a */
@@ -304,4 +304,14 @@ main {
 .animate-fade-in-up {
     animation: fadeInUp 0.6s ease-out forwards;
     opacity: 0; /* Start hidden, animation will make it visible */
+}
+
+/* Custom SweetAlert2 minimal styling */
+.swal2-popup {
+    background-color: var(--color-card-bg);
+    color: var(--color-text);
+}
+
+input:-webkit-autofill {
+    background-color: var(--color-card-bg) !important;
 }

--- a/app/templates/dashboard/details.html
+++ b/app/templates/dashboard/details.html
@@ -8,8 +8,8 @@
     <div class="container pt-5">
         <div class="row justify-content-center">
             <div class="col-lg-9 col-md-10">
-                <article class="card shadow-sm mb-4">
-                    <div class="card-header bg-light py-3">
+                <article class="card diary-detail-card shadow-sm mb-4">
+                    <div class="card-header py-3">
                         <h1 class="card-title display-6 mb-0">{{ diary_entry.title }}</h1>
                     </div>
                     <div class="card-body p-4">
@@ -56,7 +56,7 @@
                                     {% if diary_entry.emotion_details_json %}
                                         <div class="card emotion-details-card mt-3">
                                             <div class="card-body p-3">
-                                                <h6 class="card-subtitle mb-2 text-muted">Full Emotion Scores:</h6>
+                                                <h6 class="card-subtitle mb-2">Full Emotion Scores:</h6>
                                                 <ul class="list-unstyled mb-0">
                                                     {% for emotion in diary_entry.emotion_details_json %}
                                                         <li>
@@ -88,7 +88,7 @@
                             {% if shared_users %}
                                 <hr>
                                 <div class="mt-4">
-                                    <h5 class="text-muted"><i class="bi bi-people-fill"></i> Shared With:</h5>
+                                    <h5 class="shared-with-label"><i class="bi bi-people-fill"></i> Shared With:</h5>
                                     <ul class="list-unstyled">
                                         {% for user in shared_users %}
                                             <li><i class="bi bi-person"></i> {{ user.username }}</li>


### PR DESCRIPTION
Summary

This pull request implements dark mode support across the entire diary web interface.

Changes
	•	Updated style.css:
	•	Defined dark mode colors under @media (prefers-color-scheme: dark)
	•	Centralized theme via --color-* variables
	•	Adjusted diary.css:
	•	Dark-aware backgrounds for .diary-card, .diary-detail-card, emotion analysis sections
	•	Correct contrast for text, meta-info, and emotion badges
	•	Consistent styles for search and filter input fields
	•	Applied styles to override Chrome’s yellow background using input:-webkit-autofill
	•	Unified upload form and modals:
	•	Adapted modal and form styles to match the active theme

Screens Verified
	•	Diary Home Page
	•	Diary Detail View
	•	Upload Page
	•	Share Modal

Closes #61
<img width="1499" alt="Screenshot 2025-05-13 at 10 03 00" src="https://github.com/user-attachments/assets/31dcbea1-885f-48a4-954c-54c5a60568c2" />
<img width="1505" alt="Screenshot 2025-05-13 at 10 02 39" src="https://github.com/user-attachments/assets/76a6cfb3-d258-4eb5-8d88-0c220ab8694e" />
<img width="1508" alt="Screenshot 2025-05-13 at 10 02 31" src="https://github.com/user-attachments/assets/00801350-c7f2-4801-82c8-d606f410d4ce" />
<img width="1506" alt="Screenshot 2025-05-13 at 10 02 21" src="https://github.com/user-attachments/assets/d9e44956-8871-4d5d-91f2-73ea7b337a06" />

